### PR TITLE
Mapping network in Style Encoder

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -250,6 +250,7 @@ class MappingNetwork(nn.Module):
                                             nn.Linear(512, style_dim))]
 
     def forward(self, z, y):
+        print("Z: ", z)
         h = self.shared(z)
         out = []
         for layer in self.unshared:

--- a/core/model.py
+++ b/core/model.py
@@ -304,7 +304,9 @@ class StyleEncoder(nn.Module):
         out = torch.stack(out, dim=1)  # (batch, num_domains, style_dim)
         idx = torch.LongTensor(range(y.size(0))).to(y.device)
         s = out[idx, y]  # (batch, style_dim)
-        s = torch.cat(s[:, 0:32, :, :], self.mapping(z, y)[:, 32:64,:,:]), dim=1)
+        s_mapping = self.mapping(z, y)
+        print("S Shape: ", s.shape, "S_Mapping Shape", s_mapping.shape)
+        s = torch.cat(s[:, 0:32, :, :], self.mapping(z, y)[:, 32:64,:,:], dim=1)
         return s
 
 

--- a/core/model.py
+++ b/core/model.py
@@ -196,7 +196,7 @@ class Generator(nn.Module):
 
         if img_size == 128:
             constant = 4
-        else if img_size == 256:
+        elif img_size == 256:
             constant = 8
 
         n = []
@@ -250,7 +250,7 @@ class MappingNetwork(nn.Module):
                                             nn.Linear(512, style_dim))]
 
     def forward(self, z, y):
-        print("Z: ", z)
+        print("From mapping-network Z: ", z.shape)
         h = self.shared(z)
         out = []
         for layer in self.unshared:

--- a/core/solver.py
+++ b/core/solver.py
@@ -102,8 +102,8 @@ class Solver(nn.Module):
             x_real, y_org = inputs.x_src, inputs.y_src
             x_ref, x_ref2, y_trg = inputs.x_ref, inputs.x_ref2, inputs.y_ref
             z_trg, z_trg2 = inputs.z_trg, inputs.z_trg2
-            print("z_trg: ", z_trg, "z_trg2: ", z_trg2)
-            print("x_ref: ", x_ref, "x_ref2: ", x_ref2)
+            #print("z_trg: ", z_trg.shape, "z_trg2: ", z_trg2.shape) [batch, latent-dim]
+            #print("x_ref: ", x_ref.shape, "x_ref2: ", x_ref2.shape) [image]
 
             masks = nets.fan.get_heatmap(x_real) if args.w_hpf > 0 else None
 

--- a/core/solver.py
+++ b/core/solver.py
@@ -103,6 +103,7 @@ class Solver(nn.Module):
             x_ref, x_ref2, y_trg = inputs.x_ref, inputs.x_ref2, inputs.y_ref
             z_trg, z_trg2 = inputs.z_trg, inputs.z_trg2
             print("z_trg: ", z_trg, "z_trg2: ", z_trg2)
+            print("x_ref: ", x_ref, "x_ref2: ", x_ref2)
 
             masks = nets.fan.get_heatmap(x_real) if args.w_hpf > 0 else None
 

--- a/core/solver.py
+++ b/core/solver.py
@@ -102,6 +102,7 @@ class Solver(nn.Module):
             x_real, y_org = inputs.x_src, inputs.y_src
             x_ref, x_ref2, y_trg = inputs.x_ref, inputs.x_ref2, inputs.y_ref
             z_trg, z_trg2 = inputs.z_trg, inputs.z_trg2
+            print("z_trg: ", z_trg, "z_trg2: ", z_trg2)
 
             masks = nets.fan.get_heatmap(x_real) if args.w_hpf > 0 else None
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 import os
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-os.environ["CUDA_VISIBLE_DEVICES"] = "3"
+os.environ["CUDA_VISIBLE_DEVICES"] = "2"
 import argparse
 
 from munch import Munch

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 import os
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-os.environ["CUDA_VISIBLE_DEVICES"] = "2"
+os.environ["CUDA_VISIBLE_DEVICES"] = "3"
 import argparse
 
 from munch import Munch
@@ -176,7 +176,7 @@ if __name__ == '__main__':
 
     # step size
     parser.add_argument('--print_every', type=int, default=10)
-    parser.add_argument('--sample_every', type=int, default=25000)
+    parser.add_argument('--sample_every', type=int, default=10000)
     parser.add_argument('--save_every', type=int, default=10000)
     parser.add_argument('--eval_every', type=int, default=5000)
 

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-nohup python main.py --mode train --num_domains 2 --w_hpf 1 --lambda_reg 1 --lambda_sty 1 --lambda_ds 1 --lambda_cyc 1 --train_img_dir data/celeba_hq/train --val_img_dir data/celeba_hq/val &> log.out &
+nohup python main.py --mode train --num_domains 2 --w_hpf 1 --lambda_reg 1 --lambda_sty 1 --lambda_ds 1 --lambda_cyc 1 --train_img_dir data/celeba_hq/train --val_img_dir data/celeba_hq/val --img_size 128 --eval_every 5000  &> log.out &


### PR DESCRIPTION
z'nin dimension'ları [batch_size, latent_dim], bizim çalıştırma settings'imiz için [8, 16]
z, data_loader.py 198.satırda torch.randn ile üretiliyor.
1. StyleEncoder init içinde 
- Style dimension'ı yarıya indirdim, model.py 269.satır
- MappingNetwork'ü model.py 293.satırda oluşturdum. 
2. StyleEncoder forward methodu içinde, model.py 295.satır;
- z'yi data_loader'daki gibi oluşturdum.
- self.mapping(z, y) methodu [batch_size, style_dim] boyutlarında matrix döndürüyor, bizim çalıştırma setting'imiz için [8, 32]
- model.py, 307.satırdaki s'nin dimensionları [batch_size, style_dim], bizim çalıştırma setting'imiz için [8,32]
- s ile s_mapping'i model.py 311.satırda birleştirdim. Çıkan s [batch_size, style_dim*2], bizim setting'de [8, 64]